### PR TITLE
Feat/홈페이지 캐러셀 구현

### DIFF
--- a/src/components/carousel/carousel.jsx
+++ b/src/components/carousel/carousel.jsx
@@ -1,9 +1,72 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import { Article } from './carouselstyle'
 
-export default function carousel() {
+const bannerData = [
+    {
+        id: 1,
+        name: '광고1',
+        image: 'https://pixabay.com/get/ge42b02d348e5d0ae8fa677996638b841043a769037bdd246029c8f685b37f75fb0ec3523e09665a1c2ab443da8155b5167421b0c7683f9e79f5720fd6bf22822b299a8b9461bba764364a16dd5e1f0b4_1280.jpg'
+    },
+    {
+        id: 2,
+        name: '광고2',
+        image: 'https://pixabay.com/get/g381663a3f12d006db061b9d433c1de7864415869c8b108b484a891c345d6ecb61ad6195a4eb3a25446e7ec50ebee1c8c5ee4ad82d280e4c0dd81f6d393a0d1e6568a6b4c31982a0f0f9d2794dc3fd9b7_1280.jpg'
+    },
+    {
+        id: 3,
+        name: '광고3',
+        image: 'https://pixabay.com/get/gc0bd4217638e85c3041930e42f53396c9af5b6dd853c3d8c4ad1e1a4259e7f443d5b9b673729b3a29ab794e340038fde82e459924de63a8db1705f87baf6e3e326cfc2020c8db9ede5d8e043d79ae7b8_1280.jpg'
+    },
+]
+
+export function Carousel() {
+    const banners = bannerData;
+    const [index, setIndex] = useState(0);
+
+    useEffect(() => {
+        const lastIndex = banners.length - 1;
+
+        if(index < 0) {
+            setIndex(lastIndex);
+        }
+        if(index > lastIndex) {
+            setIndex(0)
+        }
+    }, [index])
+
+    useEffect(() => {
+        const slider = setInterval(() => {
+            setIndex(index + 1)
+        }, 3000);
+
+        return () => {return clearInterval(slider)};
+    }, [index])
+
   return (
-    <div>
-      carousel
-    </div>
+    <Article>
+      <ul className='bannerWrap'>
+        {banners.map((banner, bannerIndex) => {
+            const { id, name, image } = banner;
+            let position = 'nextSlider'
+
+            if(bannerIndex === index) {
+                position = 'activeSlide';
+            }
+            if(bannerIndex === index -1 || 
+                (index === 0 && bannerIndex === banners.length - 1)) {
+                position = 'lastSlide';
+            }
+            return (
+                <li key={id} className={position}>
+                    <img src={image} alt={name} />
+                </li>
+            )
+        })}
+      </ul>
+      <div className='btnWrap'>
+        <button onClick={()=> {return setIndex(index-1)}} className='prevBtn'>◀️</button>
+        <button onClick={()=> {return setIndex(index+1)}} className='nextBtn'>▶️</button>
+      </div>
+    </Article>
   )
 }

--- a/src/components/carousel/carousel.jsx
+++ b/src/components/carousel/carousel.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function carousel() {
+  return (
+    <div>
+      carousel
+    </div>
+  )
+}

--- a/src/components/carousel/carouselstyle.jsx
+++ b/src/components/carousel/carouselstyle.jsx
@@ -1,0 +1,1 @@
+import styled from "styled-components";

--- a/src/components/carousel/carouselstyle.jsx
+++ b/src/components/carousel/carouselstyle.jsx
@@ -1,1 +1,66 @@
-import styled from "styled-components";
+import styled from 'styled-components'
+
+export const Article = styled.article`
+
+    width: 600px;
+    margin: 0 auto;
+    position: relative;
+
+    .bannerWrap {
+        width: 100%;
+        height: 550px;
+        display: flex;
+        overflow: hidden;
+    }
+
+    li {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        opacity: 0;
+    }
+
+    li.activeSlide {
+        opacity: 1;
+        transfrom : translateX(0);
+    }
+
+    li.lastSlide {
+        transform: translateX(-100%);
+    }
+
+    li.nextSlide {
+        transform: translateX(100%);
+    }
+
+    img {
+        width: 600px;
+        height: 550px;
+        object-fit: cover;
+        object-position: center;
+    }
+
+    button {
+        position: absolute;
+        cursor: pointer;
+        top: 50%;
+        transform: translateY(-50%);
+        font-size: 30px;
+        color: rgba(0, 0, 0, 0.5);
+        background: rgba(255,255,255, 0.4);
+        border-radius: 20px;
+        cursor: pointer;
+    }
+
+    .prevBtn {
+        left: 10px;
+        padding: 30px 20px 30px 15px;
+    }
+
+    .nextBtn {
+        right: 10px;
+        padding: 30px 15px 30px 20px;
+    }
+
+`

--- a/src/pages/home/Home2.jsx
+++ b/src/pages/home/Home2.jsx
@@ -1,14 +1,15 @@
 import React from 'react'
 // import { Link } from 'react-router-dom';
+import { Carousel } from '../../components/carousel/carousel'
 import { Header } from '../../components/header/header'
 import { NavBar } from '../../components/navbar/navBar'
-import { HomeBannerImg, HomeSection, Hidden, HomeTitle, ListWrap, ListItem, CardWrap, CardImg, CardCont, CardTitle, CardTxt, CardUser,   } from './homestyle'
+import { HomeSection, Hidden, HomeTitle, ListWrap, ListItem, CardWrap, CardImg, CardCont, CardTitle, CardTxt, CardUser,   } from './homestyle'
 
 const Home2 = () => {
   return (
     <main>
         <Header />
-        <HomeBannerImg />
+        <Carousel />
         <HomeSection>
             <Hidden>Home 피드 페이지</Hidden>
             <HomeTitle>럿킷 메이트를 기다리고 있어요!✨</HomeTitle>

--- a/src/pages/home/home.jsx
+++ b/src/pages/home/home.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { Carousel } from '../../components/carousel/carousel';
 import { Header } from '../../components/header/header';
 import { NavBar } from '../../components/navbar/navBar';
-import { HomeWrap, HomeBannerImg, SearchBtn, HomeTxt } from './homestyle';
+import { HomeWrap, SearchBtn, HomeTxt } from './homestyle';
 
 const Home = () => {
   return (
     <HomeWrap>
       <Header />
-      <HomeBannerImg />
+      <Carousel />
       <HomeTxt>딱 맞는 취미 메이트를 찾고 싶다면?</HomeTxt>
       <Link to='/search'>
         <SearchBtn>검색하기</SearchBtn>


### PR DESCRIPTION
### 🍀 무엇을 위한 PR인가요?
- [x] 기능 추가 : 홈페이지 캐러셀 컴포넌트 구현 및 home.jsx, Home2.jsx에 적용 
- [ ] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 


### 🙏🏻 기대 결과
- 이전 버튼, 다음 버튼 클릭 시 슬라이드가 각각 이전, 다음으로 넘어감
- 버튼을 클릭하지 않아도 3초 간격으로 오른쪽 슬라이드로 넘어감 

### 🙂 전달사항
- 구현한 이미지는 임시로 설정하였고, 추후 전달받은 이미지로 수정할 계획입니다.
- 피그마에는 버튼이 없고 아래 슬라이드 바 형태로 되어 있는데, 우선은 버튼으로 구현했습니다.
- 나중에 슬라이드 바가 넘어가는 형태로 수정하되 시간이 없다면 슬라이드 바가 포함된 이미지를 사용하고, 버튼은 투명 처리해서 구현해도 좋을 것 같습니다. (상황 보면서 추후 논의하면 좋을 거 같아요!)
- 팔로잉이 있을 때 나타나는 Home2.jsx는 기능 구현하면서 파일명 변경할 예정입니다!


### 📸 스크린샷


### 😉 Issue Number
close : #

