### PR TITLE
Feat/sns피드 페이지 구현

### DIFF
--- a/src/components/mainpost/mainSnsPost.jsx
+++ b/src/components/mainpost/mainSnsPost.jsx
@@ -1,13 +1,19 @@
 import React from 'react'
 import { NavLink } from 'react-router-dom'
-import {MainSnsPostWhap,IconWrap, SnsIdWhap, SnsPostBox} from './mainpoststyle'
+import {MainSnsPostWhap,IconWrap, SnsIdWhap, SnsPostBox,UserProfileImg, SnsPostImg, SnsPostContent} from './mainpoststyle'
 import { MoreBtn } from "../button/iconBtn";
+import DefaultUserImg from '../../assets/icon/basic-profile-img-.png'
+
+const onErrorImg = (e) => {
+  e.target.src = DefaultUserImg;
+}
 
 const MainSnsPost = ({data}) => {
+
   return (
     <MainSnsPostWhap>
        <NavLink to='/yourprofile'>
-      <img src={data.author.image} alt="프로필이미지" />
+      <UserProfileImg src={data.author.image} onError={onErrorImg} />
       </NavLink>
       <SnsPostBox>
       <NavLink to='/yourprofile'>
@@ -17,8 +23,8 @@ const MainSnsPost = ({data}) => {
       </SnsIdWhap>
       </NavLink>
       <NavLink to='/snsPost'>
-      <p>{data.content}</p>
-      <img src={data.image} alt="게시글이미지" />
+      <SnsPostContent>{data.content}</SnsPostContent>
+      <SnsPostImg src={data.image} onError = {e =>{e.target.style.display = 'none'}}/>
       </NavLink>
       <IconWrap>
       <button>좋아요버튼</button>

--- a/src/components/mainpost/mainSnsPost.jsx
+++ b/src/components/mainpost/mainSnsPost.jsx
@@ -3,22 +3,22 @@ import { NavLink } from 'react-router-dom'
 import {MainSnsPostWhap,IconWrap, SnsIdWhap, SnsPostBox} from './mainpoststyle'
 import { MoreBtn } from "../button/iconBtn";
 
-const MainSnsPost = () => {
+const MainSnsPost = ({data}) => {
   return (
     <MainSnsPostWhap>
        <NavLink to='/yourprofile'>
-      <img src="https://search.pstatic.net/common/?src=http%3A%2F%2Fcafefiles.naver.net%2F20160622_226%2Fsang7145_1466595386985CQdGk_JPEG%2Fg.jpg&type=sc960_832" alt="프로필이미지" />
+      <img src={data.author.image} alt="프로필이미지" />
       </NavLink>
       <SnsPostBox>
       <NavLink to='/yourprofile'>
       <SnsIdWhap>
-      <strong>몰랑몰랑</strong>
-      <p>@molang</p>
+      <strong>{data.author.username}</strong>
+      <p>@{data.author.accountname}</p>
       </SnsIdWhap>
       </NavLink>
       <NavLink to='/snsPost'>
-      <p>몰랑이는 너무 귀여운 것 같아용!</p>
-      <img src="https://search.pstatic.net/common/?src=http%3A%2F%2Fcafefiles.naver.net%2F20160622_226%2Fsang7145_1466595386985CQdGk_JPEG%2Fg.jpg&type=sc960_832" alt="게시글이미지" />
+      <p>{data.content}</p>
+      <img src={data.image} alt="게시글이미지" />
       </NavLink>
       <IconWrap>
       <button>좋아요버튼</button>

--- a/src/components/mainpost/mainpoststyle.jsx
+++ b/src/components/mainpost/mainpoststyle.jsx
@@ -5,64 +5,71 @@ const MainSnsPostWhap= styled.div`
     box-sizing: border-box;
     margin-top: 20px;
     width: 100%;
-    height: 350px;
     background: rgb(255, 255, 255);
     display: flex;
     z-index: 10;
     border-top-right-radius:10px;
     border-top-left-radius: 10px;
     overflow: hidden;
-img{
+`;
+
+export { MainSnsPostWhap }
+
+const UserProfileImg= styled.img`
       margin: 0 20px;
       border-radius: 50%;
       width: 80px;
       height: 80px;
-}
 `;
 
-export { MainSnsPostWhap }
+export { UserProfileImg }
 
 const SnsPostBox= styled.div`
     align-items: left;
     box-sizing: border-box;
     width: 90%;
-    height: 350px;
     background: rgb(255, 255, 255);
     display: flex;
     flex-direction: column;
     z-index: 10;
-p{
-    margin: 10px 0px;
-    font-size: 14px;
-    line-height: 16px;
-}
-img{
-      margin-top:20px;
-      border-radius: 10px;
-      width: 319px;
-      height: 264px;
-}
 `;
 
 export { SnsPostBox }
 
+const SnsPostContent= styled.p`
+      margin: 15px 0px;
+      font-weight: 300;
+    font-size: 18px;
+    line-height: 16px;
+`;
+
+export { SnsPostContent }
+
+const SnsPostImg= styled.img`
+      border-radius: 10px;
+      width: 355px;
+      height: 264px;
+`;
+
+export { SnsPostImg }
+
 const SnsIdWhap= styled.div`
     left:0;
     box-sizing: border-box;
-    width: 50%;
     height: 14px;
     background: rgb(255, 255, 255);
     display: flex;
+    justify-items:center;
+    align-items: baseline;
     z-index: 10;
     > strong{
-    margin: 10px 0px;
-    font-size: 14px;
+    margin-right:5px;
+    font-size: 16px;
     line-height: 14px;
-    font-weight: 500;
+    font-weight: 600;
 }
 > p{
-    margin: 10px 0px;
-    font-size: 10px;
+    font-size: 12px;
     line-height: 11px;
 }
 `;
@@ -77,12 +84,7 @@ const IconWrap= styled.div`
     background: rgb(255, 255, 255);
     display: flex;
     z-index: 10;
-    > strong{
     margin: 10px 0px;
-    font-size: 14px;
-    line-height: 14px;
-    font-weight: 500;
-}
 >button{
     cursor: pointer;
 }

--- a/src/pages/sns/snsPage.jsx
+++ b/src/pages/sns/snsPage.jsx
@@ -1,9 +1,9 @@
 import React,{ useEffect , useState} from 'react';
 import MainSnsPost from '../../components/mainpost/mainSnsPost'
-import { SnsPageArt, SnsPageSec, MainPostArea } from './snsstyle';
+import { SnsPageArt, SnsPageSec, MainPostArea, SnsStoryImg } from './snsstyle';
 import { FeedPageHeader } from '../../components/header/header';
 import { NavBar } from '../../components/navbar/navBar';
-
+import DefaultUserImg from '../../assets/icon/basic-profile-img-.png'
 
 export const SnsPage = () => {
   
@@ -51,7 +51,7 @@ export const SnsPage = () => {
       .then((data) => data.json())
       .then((data) => {
         const myStoryImg = {image : data.user.image}
-
+        
         setFollowList(value => [ myStoryImg, ...value] )
       })
 }
@@ -61,13 +61,17 @@ export const SnsPage = () => {
     fetchUserStoryData();
   },[])
 
+  const onErrorImg = (e) => {
+    e.target.src = DefaultUserImg;
+  }
+
   return (
     <>
     <FeedPageHeader />
     <SnsPageArt>
       <ul>
       {followList.map((story)=> {
-           return <li><img src={story.image} /></li>
+           return <li><SnsStoryImg src={story.image} onError={onErrorImg} /></li>
         })}
       {}
       </ul>

--- a/src/pages/sns/snsPage.jsx
+++ b/src/pages/sns/snsPage.jsx
@@ -1,5 +1,4 @@
 import React,{ useEffect , useState} from 'react';
-// import ScrollMenu from "react-horizontal-scrolling-menu";
 import MainSnsPost from '../../components/mainpost/mainSnsPost'
 import { SnsPageArt, SnsPageSec, MainPostArea } from './snsstyle';
 import { FeedPageHeader } from '../../components/header/header';
@@ -7,21 +6,17 @@ import { NavBar } from '../../components/navbar/navBar';
 
 
 export const SnsPage = () => {
-  // const [modalOpen, setModalOpen] = useState(false);
-
-  //   // 모달창 노출
-  //   const showModal = () => {
-  //       setModalOpen(!modalOpen);
-  //   };
   
   const [list ,setList] = useState([]);
-  // const [followList,setFollowList] = useState([]);
+  const [followList,setFollowList] = useState([]);
   const URL = `https://mandarin.api.weniv.co.kr`;
   const FEED_PATH = `/post/feed`;
-  // const STORY_PATH=`/profile/:accountname/following`;
+  const STORY_PATH=`/profile/fffffff/following`;
+  const USER_PATH=`/user/myinfo`;
   const token =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzOTA5MzIwMTdhZTY2NjU4MWMwMzNlNyIsImV4cCI6MTY3NjQ0NDc2OSwiaWF0IjoxNjcxMjYwNzY5fQ.PcmkXNY7JTV8PlIYVh9XOCbYhiD789NfFYXrjOQ6_ik';
   
+  // 팔로잉한 유저의 게시글 정보 불러오는 fetch
   async function fetchFeedPostData(){
     await fetch(URL+FEED_PATH, {
       method: 'GET',
@@ -33,25 +28,37 @@ export const SnsPage = () => {
     .then((data) => data.json())
     .then((data) =>  {
       setList(data.posts)
-      // console.log(data.posts)
     });
   }
-  // async function fetchUserStoryData() {
-    
-  //   await fetch( URL+STORY_PATH, {
-  //     method: 'GET',
-  //     headers: {
-  //       Authorization: `Bearer ${token}`,
-  //       'Content-type': 'application/json',
-  //     },
-  //   })
-  //     .then((data) => data.json())
-  //     .then((data) => console.log([...data]))
-  //     /* setFollowList([...data]));*/
-  // }
+// 팔로잉한 유저 프로필 정보 불러오는 fetch
+  async function fetchUserStoryData() {  
+    await fetch( URL+STORY_PATH, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-type': 'application/json',
+      },
+    })
+      .then((data) => data.json())
+      .then((data) =>setFollowList([...data]))
+      // 내 프로필 정보 불러오는 fetch
+      await fetch( URL+USER_PATH, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`
+        },  
+  })
+      .then((data) => data.json())
+      .then((data) => {
+        const myStoryImg = {image : data.user.image}
+
+        setFollowList(value => [ myStoryImg, ...value] )
+      })
+}
+
   useEffect( ()=>{
     fetchFeedPostData();
-    // fetchUserStoryData();
+    fetchUserStoryData();
   },[])
 
   return (
@@ -59,9 +66,10 @@ export const SnsPage = () => {
     <FeedPageHeader />
     <SnsPageArt>
       <ul>
-      {/* {followList.map((story)=> {
+      {followList.map((story)=> {
            return <li><img src={story.image} /></li>
-        })} */}
+        })}
+      {}
       </ul>
     </SnsPageArt>
     <SnsPageSec>

--- a/src/pages/sns/snsPage.jsx
+++ b/src/pages/sns/snsPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React,{ useEffect , useState} from 'react';
 // import ScrollMenu from "react-horizontal-scrolling-menu";
 import MainSnsPost from '../../components/mainpost/mainSnsPost'
 import { SnsPageArt, SnsPageSec, MainPostArea } from './snsstyle';
@@ -14,42 +14,62 @@ export const SnsPage = () => {
   //       setModalOpen(!modalOpen);
   //   };
   
+  const [list ,setList] = useState([]);
+  // const [followList,setFollowList] = useState([]);
+  const URL = `https://mandarin.api.weniv.co.kr`;
+  const FEED_PATH = `/post/feed`;
+  // const STORY_PATH=`/profile/:accountname/following`;
+  const token =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzOTA5MzIwMTdhZTY2NjU4MWMwMzNlNyIsImV4cCI6MTY3NjQ0NDc2OSwiaWF0IjoxNjcxMjYwNzY5fQ.PcmkXNY7JTV8PlIYVh9XOCbYhiD789NfFYXrjOQ6_ik';
+  
+  async function fetchFeedPostData(){
+    await fetch(URL+FEED_PATH, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-type': 'application/json',
+      },
+    })
+    .then((data) => data.json())
+    .then((data) =>  {
+      setList(data.posts)
+      // console.log(data.posts)
+    });
+  }
+  // async function fetchUserStoryData() {
+    
+  //   await fetch( URL+STORY_PATH, {
+  //     method: 'GET',
+  //     headers: {
+  //       Authorization: `Bearer ${token}`,
+  //       'Content-type': 'application/json',
+  //     },
+  //   })
+  //     .then((data) => data.json())
+  //     .then((data) => console.log([...data]))
+  //     /* setFollowList([...data]));*/
+  // }
+  useEffect( ()=>{
+    fetchFeedPostData();
+    // fetchUserStoryData();
+  },[])
+
   return (
     <>
     <FeedPageHeader />
     <SnsPageArt>
       <ul>
-        <li>
-          <img src="https://search.pstatic.net/common/?src=http%3A%2F%2Fcafefiles.naver.net%2F20160622_226%2Fsang7145_1466595386985CQdGk_JPEG%2Fg.jpg&type=sc960_832" alt="스토리이미지1" />
-        </li>
-        <li>
-          <img src="https://search.pstatic.net/common/?src=http%3A%2F%2Fcafefiles.naver.net%2F20160622_226%2Fsang7145_1466595386985CQdGk_JPEG%2Fg.jpg&type=sc960_832" alt="스토리이미지1" />
-        </li>
-        <li>
-          <img src="https://search.pstatic.net/common/?src=http%3A%2F%2Fcafefiles.naver.net%2F20160622_226%2Fsang7145_1466595386985CQdGk_JPEG%2Fg.jpg&type=sc960_832" alt="스토리이미지1" />
-        </li>
-        <li>
-          <img src="https://search.pstatic.net/common/?src=http%3A%2F%2Fcafefiles.naver.net%2F20160622_226%2Fsang7145_1466595386985CQdGk_JPEG%2Fg.jpg&type=sc960_832" alt="스토리이미지1" />
-        </li>
-        <li>
-          <img src="https://search.pstatic.net/common/?src=http%3A%2F%2Fcafefiles.naver.net%2F20160622_226%2Fsang7145_1466595386985CQdGk_JPEG%2Fg.jpg&type=sc960_832" alt="스토리이미지1" />
-        </li>
-        <li>
-          <img src="https://search.pstatic.net/common/?src=http%3A%2F%2Fcafefiles.naver.net%2F20160622_226%2Fsang7145_1466595386985CQdGk_JPEG%2Fg.jpg&type=sc960_832" alt="스토리이미지1" />
-        </li>
-        <li>
-          <img src="https://search.pstatic.net/common/?src=http%3A%2F%2Fcafefiles.naver.net%2F20160622_226%2Fsang7145_1466595386985CQdGk_JPEG%2Fg.jpg&type=sc960_832" alt="스토리이미지1" />
-        </li>
-        <li>
-          <img src="https://search.pstatic.net/common/?src=http%3A%2F%2Fcafefiles.naver.net%2F20160622_226%2Fsang7145_1466595386985CQdGk_JPEG%2Fg.jpg&type=sc960_832" alt="스토리이미지1" />
-        </li>
+      {/* {followList.map((story)=> {
+           return <li><img src={story.image} /></li>
+        })} */}
       </ul>
     </SnsPageArt>
     <SnsPageSec>
       <h1>럭킷들의 새로운 소식을 확인해보세요!</h1>
       <MainPostArea>
-      <MainSnsPost/>
-      <MainSnsPost/>
+        {list.map((value)=> {
+           return < MainSnsPost data={value} key={value._id} />
+        })}
       </MainPostArea>
     </SnsPageSec>
     <NavBar />

--- a/src/pages/sns/snsstyle.jsx
+++ b/src/pages/sns/snsstyle.jsx
@@ -149,22 +149,27 @@ const SnsPageArt = styled.article`
         margin-right:0px;
       }
     }
-    li > img{
+`;
+
+export { SnsPageArt }
+
+const SnsStoryImg =styled.img`
+      box-sizing: inherit;
       border: 3px solid #85CE2D;
       border-radius: 50%;
       width: 80px;
       height: 80px;
-    }
+
 `;
 
-export { SnsPageArt }
+export { SnsStoryImg }
 
 const SnsPageSec= styled.section`
   align-items: center;
     box-sizing: border-box;
     width: 95%;
     margin: 15px;
-    height: 70%;
+    height: 79%;
     top: 0px;
     background: rgb(255, 255, 255);
     display: flex;


### PR DESCRIPTION
### 🍀 무엇을 위한 PR인가요?
- [x] 기능 추가 :  sns피드 페이지 구현
- [ ] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 


### 🙏🏻 기대 결과
- 나와 내팔로워의 프로필 이미지를 스토리 형식으로 조회 가능
- 내팔로워의 게시글을 조회 가능
- 유저 프로필이 없을 때 럭킷 기본이미지로 띠워줌
- 게시글 이미지가 없을 때 이미지 태그를 숨겨줌

### 🙂 전달사항
-


### 📸 스크린샷


### 😉 Issue Number
close : #60

