### PR TITLE
Fix: sns게시글, 댓글 더보기 버튼 모달 기능 수정

### DIFF
--- a/src/components/button/iconBtn.jsx
+++ b/src/components/button/iconBtn.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams } from 'react-router-dom';
+// import { useParams } from 'react-router-dom';
 import { IconBtn } from './iconBtnstyle';
 // import addBtn from '../../assets/icon/addBtn.svg';
 import moreBtn from '../../assets/icon/s-icon-more-vertical.png';
@@ -19,10 +19,9 @@ export function ImgUploadBtn({ posi, click }) {
   return <IconBtn onClick={click} icon={imgBtn} posi={posi}></IconBtn>;
 }
 /* Sns게시글 더보기 버튼 */
-export function MoreBtn({postId}) {
+export function MoreBtn({postId, accountname}) {
   const [isOpen, setIsOpen] = useState(false);
   const accountName = localStorage.getItem("Account Name");
-  const {id} = useParams();
 
   const onClick = () => {
     setIsOpen(true);
@@ -35,14 +34,14 @@ export function MoreBtn({postId}) {
   return (
     <>
       <IconBtn onClick={onClick}icon={moreBtn}></IconBtn>
-      {isOpen && <SnsPostModal onClickClose={onClickClose} accountName={accountName} id={id} postId={postId} />}
+      {isOpen && <SnsPostModal onClickClose={onClickClose} accountName={accountName} postId={postId} accountname={accountname}/>}
     </>
   );
 }
 
 export function CommentMoreBtn({accountname}) {
   const [isOpen, setIsOpen] = useState(false);
-  const id = localStorage.getItem("Account Name");
+  const accountName = localStorage.getItem("Account Name");
 
   const onClick = () => {
     setIsOpen(true);
@@ -55,7 +54,7 @@ export function CommentMoreBtn({accountname}) {
   return (
     <>
       <IconBtn onClick={onClick}icon={moreBtn}></IconBtn>
-      {isOpen && <CommentModal onClickClose={onClickClose} id={id} accountname={accountname}/>}
+      {isOpen && <CommentModal onClickClose={onClickClose} accountName={accountName} accountname={accountname}/>}
     </>
   );
 }

--- a/src/components/comment/commentBox.jsx
+++ b/src/components/comment/commentBox.jsx
@@ -7,7 +7,6 @@ function CommentBox({ postId, comments, getComments }) {
     console.log('아이딩',postId)
     console.log('댓글',comments)
 
-
     return (
     <>
       <CommentListBox>

--- a/src/components/comment/commentlist/commentList.jsx
+++ b/src/components/comment/commentlist/commentList.jsx
@@ -4,7 +4,6 @@ import * as S from './commentliststyle';
 import {CommentMoreBtn} from '../../button/iconBtn'
 
 function CommentList({ comments }) {
-  const accountname = localStorage.getItem('Account Name');
 
   return (
     <S.CommentListWrapper>
@@ -19,7 +18,7 @@ function CommentList({ comments }) {
                   <small>{timeForToday(data.createdAt)}</small>
                 </S.InformationBox>
                 <S.ModalBtnBox>
-                  <CommentMoreBtn accountname={`${accountname}`}/>
+                  <CommentMoreBtn accountname={data.author.accountname}/>
                 </S.ModalBtnBox>
                 <S.CommentText>{data.content}</S.CommentText>
               </S.CommentListLi>

--- a/src/components/mainpost/mainSnsPost.jsx
+++ b/src/components/mainpost/mainSnsPost.jsx
@@ -56,7 +56,7 @@ const MainSnsPost = ({data}) => {
       </NavLink>
       </IconWrap>
       </SnsPostBox>
-      <MoreBtn postId={data.id}/>
+      <MoreBtn postId={data.id} accountname={data.author.accountname}/>
     </MainSnsPostWhap>
   )
 }

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -76,7 +76,7 @@ export const MarketPreviewModal = ({onClickClose}) => {
 }
 
 /* Sns게시글 모달 */
-export const SnsPostModal = ({onClickClose, accountName, id, postId}) => {
+export const SnsPostModal = ({onClickClose, accountName, accountname, postId}) => {
   const token = localStorage.getItem('Access Token');
   const [isOpenModal, setIsOpenModal] = useState(false)
 
@@ -112,7 +112,7 @@ export const SnsPostModal = ({onClickClose, accountName, id, postId}) => {
   return (
     <PostModalWrap onClick={() => onClickClose(false)}>
         <div className='test' onClick={(e) => e.stopPropagation()}>
-            {accountName === id ? <>
+            {accountName === accountname ? <>
             <PostModalBtnWrap>
               <button onClick={onClickDeleteModal}>삭제</button>
               <NavLinkStyle to='#'>수정</NavLinkStyle>
@@ -161,7 +161,7 @@ export const ChatRoomModal = ({onClickClose}) => {
   )
 }
 
-export const CommentModal = ({onClickClose, id, accountname}) => {
+export const CommentModal = ({onClickClose, accountname, accountName}) => {
   const [isOpenModal, setIsOpenModal] = useState(false)
 
   const onClickDeleteModal = () => {
@@ -175,7 +175,7 @@ export const CommentModal = ({onClickClose, id, accountname}) => {
   return (
     <PostModalWrap onClick={() => onClickClose(false)}>
         <div className='test' onClick={(e) => e.stopPropagation()}>
-            {accountname === id ? <>
+            {accountName === accountname ? <>
             <PostModalBtnWrap>
               <button onClick={onClickDeleteModal}>삭제</button>
               <NavLinkStyle to='#'>수정</NavLinkStyle>

--- a/src/components/sns-post/snsPost.jsx
+++ b/src/components/sns-post/snsPost.jsx
@@ -26,6 +26,7 @@ export const SnsPost = () => {
     setPostDetail(res.data.post)
  }
 
+
  const getComments = () => {
   axios({
     url: `https://mandarin.api.weniv.co.kr/post/${postId}/comments?limit=10`,
@@ -59,7 +60,8 @@ export const SnsPost = () => {
       {postDetail !== null && < MainSnsPost data={postDetail}/>} 
       <CommentBox postId={postId}
         comments={comments}
-        getComments={getComments}/>
+        getComments={getComments}
+        />
       </div>
     </SnsPostModalWrap>
   )


### PR DESCRIPTION
### 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 : sns게시글과 댓글 더보기 버튼 클릭 시 모두 신고하기 모달이 뜨는 문제가 발생되어, 각 게시글과 댓글의 'accountname' props를 이용해 내 계정과 타 계정을 구분, 내 계정일 시 '삭제, 수정', 타 게정일 시 '신고하기' 모달이 뜨도록 구현
- [ ] 기타 : 


### 🙏🏻 기대 결과
- 게시글과 댓글의 'accountname' props를 이용해 내 계정과 타 계정을 구분, 내 계정일 시 '삭제, 수정', 타 게정일 시 '신고하기' 모달이 뜨도록 구현

### 📸 스크린샷


### 🙂 전달사항

### 😉 Issue Number
close : #112

