### PR TITLE
Refactor/검색페이지와마켓게시글코드수정

### DIFF
--- a/src/components/mainpost/marketPostBox.jsx
+++ b/src/components/mainpost/marketPostBox.jsx
@@ -11,7 +11,7 @@ import {
 import IconSnsClova from '../../assets/icon/sns용-클로바-disabled.png';
 import IconSnsClovaFill from '../../assets/icon/sns용-클로바.png';
 
-export default function MarketPostBox({data, index, id}) {
+export default function MarketPostBox({data, accountname}) {
   const [confirmedValue, setConfirmedValue] = useState(JSON.parse(localStorage.getItem('stored')));
   const myAccountName = localStorage.getItem("Account Name");
 
@@ -71,9 +71,9 @@ export default function MarketPostBox({data, index, id}) {
           <CardTitle>{data.itemName}</CardTitle>
           <CardTxt>{data.link}</CardTxt>
           <CardUser>FROM. {data.author.username}</CardUser>
-          {id !== myAccountName ? <>
-          <button onClick={onClickApplyBtn} id={index}>
-            {confirmedValue && confirmedValue[index] ? <>
+          {accountname !== myAccountName ? <>
+          <button onClick={onClickApplyBtn} id={data.id}>
+            {confirmedValue && confirmedValue[data.id] ? <>
             <img src={IconSnsClovaFill} alt='취미 메이트 신청 버튼'/>
             </> : <>
             <img src={IconSnsClova} alt='취미 메이트 신청 버튼'/>

--- a/src/components/market-preview-post/marketPreviewPost.jsx
+++ b/src/components/market-preview-post/marketPreviewPost.jsx
@@ -1,5 +1,3 @@
-
-
 import React, { useEffect } from 'react'
 import { NavLink, useParams } from 'react-router-dom'
 import { useSelector, useDispatch } from 'react-redux'
@@ -8,30 +6,16 @@ import IconMarketPostUpload from '../../assets/icon/market-plus.png'
 import { AxiosProductList } from '../../reducers/getProductListSlice'
 import IconClova from '../../assets/icon/sns용-클로바-disabled.png'
 
-
-
-
-
-
-
 export const MarketPreviewPost = () => {
-
   const accountName = localStorage.getItem("Account Name");
   const {id} = useParams()
   const product = useSelector(state => state.productListSlice.productList);
   const dispatch = useDispatch();
   const URLProduct = `https://mandarin.api.weniv.co.kr/product/${id}`;
 
-  console.log('뿌려줄거!!!!', product);
-
-
-
-
   useEffect(()=>{
     dispatch(AxiosProductList(URLProduct));
   },[])
-
- 
 
   return (
     <MarketPreviewBoxWrap>
@@ -63,8 +47,7 @@ export const MarketPreviewPost = () => {
                   </li>
                 );
               })}
-          </ul>
-        
+          </ul> 
     </MarketPreviewBoxWrap>
   );
 };

--- a/src/pages/home/MarketFeedHome.jsx
+++ b/src/pages/home/MarketFeedHome.jsx
@@ -52,10 +52,10 @@ console.log(productData)
           <HomeTitle>럿킷 메이트를 기다리고 있어요!✨</HomeTitle>
           <ListWrap>
             {productData.length > 0 &&
-              productData.map((data, index) => {
+              productData.map((data) => {
                 return (
                   <ListItem key={Math.random()}>
-                    <MarketPostBox data={data} index={index} />
+                    <MarketPostBox data={data} />
                     <MarketPostMoreBtn productId={data.id}/>
                   </ListItem>
                 );

--- a/src/pages/market/marketPost.jsx
+++ b/src/pages/market/marketPost.jsx
@@ -42,10 +42,10 @@ export function MarketPost() {
         <main>
           <ListWrap>
             {marketPostsData &&
-              marketPostsData.map((data, index) => {
+              marketPostsData.map((data) => {
                 return (
                   <ListItem key={Math.random()}>
-                    <MarketPostBox data={data} index={index} id={id} />
+                    <MarketPostBox data={data} accountname={id} />
                     <MarketPostMoreBtn productId={data.id} />
                   </ListItem>
                 );

--- a/src/pages/profile/myProfile.jsx
+++ b/src/pages/profile/myProfile.jsx
@@ -12,10 +12,7 @@ import IconPostAlbumOn from '../../assets/icon/icon-post-album-on.png';
 import IconPostAlbumOff from '../../assets/icon/icon-post-album-off.png';
 import MainSnsPost from '../../components/mainpost/mainSnsPost';
 
-
 export const Profile = () => {
- 
-
   const [snsPostsData, setSnsPostsData] = useState([]);
   const [imgList, setImgList] = useState(true);
   const [imgAlbum, setImgAlbum] = useState(false);
@@ -23,8 +20,6 @@ export const Profile = () => {
   const token = localStorage.getItem('Access Token');
 
   useEffect(() => {
-
-
 
     axios({
         method: 'get',
@@ -55,13 +50,10 @@ export const Profile = () => {
   return (
     <>
       <ProfileAndChatHeader />
-      
-
       <ProfileWrap>
           <ProfileBox/>
         <MarketPreviewPost/>
         {snsPostsData.length !== 0 ? 
-
         <section>
           <SnsPostBtn>
             <button onClick={onClickListBtn}>

--- a/src/pages/search/search.jsx
+++ b/src/pages/search/search.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { SearchHeader } from '../../components/header/header';
 import { NavBar } from '../../components/navbar/navBar';
-import { SearchMain, SearchListWrap, Span, Div, NoResultWrap } from './searchstyle'
+import { SearchMain, SearchListWrap, Span, Div, NoResultWrap, SearchResult } from './searchstyle'
 import { SnsProfileWrap, AuthorNavLink, AuthorImgNavLink } from '../profile/myprofilestyle';
 import DefaultUserImg from '../../assets/icon/basic-profile.png'
 
@@ -65,8 +65,11 @@ export const Search = () => {
                     <img src={user.image} onError={onErrorImg} alt="프로필이미지" />
                   </AuthorImgNavLink>
                   <AuthorNavLink to={`/profile/${user.accountname}`}>
-                    <KeywordColor user={user.username} word={keyword} type='username'>{user.username} </KeywordColor>
-                    <KeywordColor user={user.accountname} word={keyword} type='accountname'>@ {user.accountname}</KeywordColor>
+                    <KeywordColor user={user.username} word={keyword} type='username' />
+                    <SearchResult>
+                      <span>@</span>
+                      <KeywordColor user={user.accountname} word={keyword}type='accountname' />
+                  </SearchResult>
                   </AuthorNavLink>
                 </SnsProfileWrap>
               </li>

--- a/src/pages/search/searchstyle.jsx
+++ b/src/pages/search/searchstyle.jsx
@@ -58,7 +58,7 @@ export const Span = styled.span`
 `
 
 export const Div = styled.div`
-  display: flex;
+  display: inline;
 
   ${({ type }) => {
     return type === 'username'
@@ -72,5 +72,15 @@ export const Div = styled.div`
         `;
   }};
 
+  `
 
-`
+  export const SearchResult = styled.div`
+
+    dispaly: flex;
+
+    span {
+      margin-right: 2px;
+      font-size: 12px;
+    }
+    
+  `


### PR DESCRIPTION
### 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 스타일 : 
- [x] 리팩토링 : 검색 페이지 키워드 입력 시 계정 앞에 '@' 뜨도록 수정, 럭킷 매칭 버튼 클릭 시 local storage에 key 값 index -> product id로 저장되도록 수정
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 


### 🙏🏻 기대 결과
- 검색 페이지 키워드 입력 시 계정 앞에 '@' 뜸
- 럭킷 매칭 버튼 클릭 시 local storage에 product id가 key로 저장되어 각 게시글별로 신청 상태 저장됨

### 📸 스크린샷


### 🙂 전달사항

### 😉 Issue Number
close : #140

