### PR TITLE
Fix: 프로필 페이지 정보 불러오기 오류 수정

### DIFF
--- a/src/components/market-preview-post/marketPreviewPost.jsx
+++ b/src/components/market-preview-post/marketPreviewPost.jsx
@@ -16,7 +16,7 @@ export const MarketPreviewPost = () => {
 
   useEffect(()=>{
     dispatch(AxiosProductList(URLProduct));
-  },[])
+  },[id])
 
   return (
     <MarketPreviewBoxWrap>

--- a/src/components/profile-box/profileBox.jsx
+++ b/src/components/profile-box/profileBox.jsx
@@ -18,9 +18,14 @@ export const ProfileBox = () => {
   const myAccountName = localStorage.getItem('Account Name');
   const token = localStorage.getItem('Access Token');
 
+
+
+
   useEffect(() => {
     dispatch(AxiosUserData(BaseURL)); 
-  }, [isfollow]);
+  }, [isfollow,id]);
+
+ 
 
 
   const unfollow = async () => {


### PR DESCRIPTION
### 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 :  
- [ ] 스타일 : 
- [ ] 리팩토링 : 
- [x] 버그 수정 : 리덕스 store에서 유저 프로필 정보를 불러올때 데이터가 바로 안 불러와지는 현상이 있었습니다. 
                        useEffet의 의존성 배열에 유저 id값을 주시하게 하여 아이디가 변할때마다 다시 불러오도록 수정하였습니다. 
                        해당 결과 프로필이 바뀔때마다 바로 정보가 불러와집니다.
- [ ] 문서 수정 : 
- [ ] 기타 : 


### 🙏🏻 기대 결과
- 

### 📸 스크린샷


### 🙂 전달사항

### 😉 Issue Number
close : #

