### PR TITLE
Refactor/헤더뒤로가기컴포넌트적용과정리

### DIFF
--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -40,6 +40,7 @@ export const FeedPageHeader = () => {
   );
 };
 
+
 // 검색 페이지
 export const SearchHeader = ({ value, onChange }) => {
 
@@ -50,6 +51,7 @@ export const SearchHeader = ({ value, onChange }) => {
     </SearchHeaderWrap>
   );
 };
+
 
 // 프로필, 채팅 페이지
 export const ProfileAndChatHeader = () => {
@@ -78,29 +80,19 @@ export const ProfileAndChatHeader = () => {
 }
 
 
-// 내 팔로우 페이지 헤더
-export const FollowerHeader = () => {
+// 팔로우 페이지
+export const FollowerHeader = ({target}) => {
 
   return (
     <FollowHeaderWrap>
       <BackBtn/>
-      <strong>followers</strong>
+      <strong>{target}</strong>
     </FollowHeaderWrap>
   );
 };
 
-// 상대방 팔로우 페이지 헤더
-export const FollowingHeader = () => {
 
-  return (
-    <FollowHeaderWrap>
-      <BackBtn/>
-      <strong>followings</strong>
-    </FollowHeaderWrap>
-  );
-};
-
-// 프로필 수정 페이지 헤더
+// 프로필 수정 페이지
 export const ProfileEditHeader = ({ onClick }) => {
 
   return (
@@ -111,7 +103,8 @@ export const ProfileEditHeader = ({ onClick }) => {
   );
 };
 
-// 게시글 업로드 헤더
+
+// 게시글 업로드
 export const PostUploadHeader = ({ isActive, handlePostSns, disabled }) => {
 
   return (
@@ -121,6 +114,7 @@ export const PostUploadHeader = ({ isActive, handlePostSns, disabled }) => {
     </EditAndUploadHeaderWrap>
   );
 };
+
 
 // 채팅방 페이지
 export const ChatRoomHeader = () => {

--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { NavLink } from 'react-router-dom'
 import {
   HomeHeaderWrap,
   SearchHeaderWrap,
@@ -9,7 +9,6 @@ import {
   EditAndUploadHeaderWrap,
 } from './headerstyle';
 import IconSearch from '../../assets/icon/icon-search.png'
-import IconArrowLeft from '../../assets/icon/icon-arrow-left.png'
 import IconLuckitLogo from '../../assets/icon/icon-luckit.png'
 import IconMoreVertical from '../../assets/icon/icon- more-vertical.png'
 import { StoreBtn, UploadBtn } from '../../components/button/button'
@@ -17,43 +16,35 @@ import { ChatRoomModal, LogoutModal } from '../modal/modal'
 import { BackBtn } from '../button/iconBtn';
 
 
-// 팔로잉 없을 때 홈페이지, 팔로잉 있을 때 홈페이지(스크롤X)
+// 팔로잉 없을 때 홈페이지, 팔로잉 있을 때 홈페이지(스크롤x)
 export const HomepageHeader = () => {
   return (
     <HomeHeaderWrap>
-      <Link to='/search'>
+      <NavLink to='/search'>
         <img src={IconSearch} alt='검색' className='searchImg' />
-      </Link>
+      </NavLink>
     </HomeHeaderWrap>
   );
 };
 
 
-// 팔로잉 있을 때 홈페이지 스크롤 내릴 경우, SNS 피드 펭지
+// 팔로잉 있을 때 홈페이지 스크롤 내릴 경우, SNS 피드 페이지
 export const FeedPageHeader = () => {
   return (
     <FeedHeaderWrap>
       <img src={IconLuckitLogo} alt='럭킷 로고' className='logoImg' />
-      <Link to='/search'>
+      <NavLink to='/search'>
         <img src={IconSearch} alt='검색' className='searchImg' />
-      </Link>
+      </NavLink>
     </FeedHeaderWrap>
   );
 };
 
 // 검색 페이지
 export const SearchHeader = ({ value, onChange }) => {
-  // const navigate = useNavigate();
 
   return (
     <SearchHeaderWrap>
-      {/* <button
-        onClick={() => {
-          navigate(-1);
-        }}
-      >
-        <img src={IconArrowLeft} alt='뒤로가기' />
-      </button> */}
       <BackBtn/>
       <input type='search' placeholder='계정 검색' value={value} onChange={onChange} />
     </SearchHeaderWrap>
@@ -63,7 +54,6 @@ export const SearchHeader = ({ value, onChange }) => {
 // 프로필, 채팅 페이지
 export const ProfileAndChatHeader = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const navigate = useNavigate();
 
   const onClick = () => {
     setIsOpen(true);
@@ -76,9 +66,7 @@ export const ProfileAndChatHeader = () => {
   return (
     <>
       <ProfileHeaderWrap>
-        <button onClick={() => {navigate(-1)}}>
-          <img src={IconArrowLeft} alt='뒤로가기' />
-        </button>
+        <BackBtn/>
         <button onClick={onClick}>
           <img src={IconMoreVertical} alt='설정 및 로그아웃 버튼' />
         </button>
@@ -92,17 +80,10 @@ export const ProfileAndChatHeader = () => {
 
 // 내 팔로우 페이지 헤더
 export const FollowerHeader = () => {
-  const navigate = useNavigate();
 
   return (
     <FollowHeaderWrap>
-      <button
-        onClick={() => {
-          navigate(-1);
-        }}
-      >
-        <img src={IconArrowLeft} alt='뒤로가기' />
-      </button>
+      <BackBtn/>
       <strong>followers</strong>
     </FollowHeaderWrap>
   );
@@ -110,17 +91,10 @@ export const FollowerHeader = () => {
 
 // 상대방 팔로우 페이지 헤더
 export const FollowingHeader = () => {
-  const navigate = useNavigate();
 
   return (
     <FollowHeaderWrap>
-      <button
-        onClick={() => {
-          navigate(-1);
-        }}
-      >
-        <img src={IconArrowLeft} alt='뒤로가기' />
-      </button>
+      <BackBtn/>
       <strong>followings</strong>
     </FollowHeaderWrap>
   );
@@ -128,18 +102,10 @@ export const FollowingHeader = () => {
 
 // 프로필 수정 페이지 헤더
 export const ProfileEditHeader = ({ onClick }) => {
-  const navigate = useNavigate();
 
   return (
     <EditAndUploadHeaderWrap>
-      <button
-        onClick={() => {
-          navigate(-1);
-        }}
-        className='backBtn'
-      >
-        <img src={IconArrowLeft} alt='뒤로가기' />
-      </button>
+      <BackBtn/>
       <StoreBtn onClick={onClick} size='middle-sm' />
     </EditAndUploadHeaderWrap>
   );
@@ -147,18 +113,10 @@ export const ProfileEditHeader = ({ onClick }) => {
 
 // 게시글 업로드 헤더
 export const PostUploadHeader = ({ isActive, handlePostSns, disabled }) => {
-  const navigate = useNavigate();
 
   return (
     <EditAndUploadHeaderWrap>
-      <button
-        onClick={() => {
-          navigate(-1);
-        }}
-        className='backBtn'
-      >
-        <img src={IconArrowLeft} alt='뒤로가기' />
-      </button>
+      <BackBtn/>
       <UploadBtn size='middle-sm' isActive={isActive} handlePostSns={handlePostSns} disabled={disabled} text='저장' />
     </EditAndUploadHeaderWrap>
   );
@@ -167,7 +125,6 @@ export const PostUploadHeader = ({ isActive, handlePostSns, disabled }) => {
 // 채팅방 페이지
 export const ChatRoomHeader = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const navigate = useNavigate();
 
   const onClick = () => {
     setIsOpen(true);
@@ -179,13 +136,7 @@ export const ChatRoomHeader = () => {
 
   return (
     <ProfileHeaderWrap>
-      <button
-        onClick={() => {
-          navigate(-1);
-        }}
-      >
-        <img src={IconArrowLeft} alt='뒤로가기' />
-      </button>
+      <BackBtn/>
       <strong>유저 네임 data 또는 그냥 지정</strong>
       <button onClick={onClick}>
         <img src={IconMoreVertical} alt='채팅방 나가기 버튼' />
@@ -194,4 +145,3 @@ export const ChatRoomHeader = () => {
     </ProfileHeaderWrap>
   );
 };
-

--- a/src/components/header/headerstyle.jsx
+++ b/src/components/header/headerstyle.jsx
@@ -11,6 +11,8 @@ export const BasicHeader = styled.header`
   top: 0;
   height: 48px;
   z-index: 99;
+  background-color: white;
+  border-bottom: 1px solid #dbdbdb;
 
   img {
     width: 24px;
@@ -27,11 +29,12 @@ export const BasicHeader = styled.header`
 export const HomeHeaderWrap = styled(BasicHeader)`
   justify-content: flex-end;
   padding: 12px 16px;
+  background-color: transparent;
+  border-bottom: none;
 `;
 
 export const SearchHeaderWrap = styled(BasicHeader)`
   padding: 8px 16px 8px 16px;
-  border-bottom: 1px solid #dbdbdb;
 
   input {
     width: 92%;
@@ -50,8 +53,6 @@ export const SearchHeaderWrap = styled(BasicHeader)`
 
 export const FeedHeaderWrap = styled(BasicHeader)`
   padding: 12px 16px;
-  background-color: white;
-  border-bottom: 1px solid #dbdbdb;
 
   .logoImg {
     width: 100px;
@@ -61,15 +62,11 @@ export const FeedHeaderWrap = styled(BasicHeader)`
 
 export const ProfileHeaderWrap = styled(BasicHeader)`
   padding: 12px 14px 12px 16px;
-  background-color: white;
-  border-bottom: 1px solid #dbdbdb;
 `;
 
 export const FollowHeaderWrap = styled(BasicHeader)`
   justify-content: flex-start;
   padding: 12px 16px;
-  background-color: white;
-  border-bottom: 1px solid #dbdbdb;
 
   strong {
     display: block;
@@ -81,22 +78,15 @@ export const FollowHeaderWrap = styled(BasicHeader)`
 
 export const EditAndUploadHeaderWrap = styled(BasicHeader)`
   padding: 12px 14px 12px 16px;
-  background-color: white;
-  border-bottom: 1px solid #dbdbdb;
 
-  button {
+  button + button {
     background-color: ${palette.마이너스초록};
   }
 
-  .backBtn {
-    background-color: transparent;
-  }
 `;
 
 export const ChatHeaderWrap = styled(BasicHeader)`
   padding: 12px 14px 12px 16px;
-  background-color: white;
-  border-bottom: 1px solid #dbdbdb;
 
   strong {
     width: 33.3%;

--- a/src/pages/follow/myFollow.jsx
+++ b/src/pages/follow/myFollow.jsx
@@ -47,7 +47,7 @@ export const MyFollow = () => {
 
   return (
     <>
-      <FollowerHeader />
+      <FollowerHeader target={target}/>
       <FollowPageWrap>
         <FollowPageUl>
           {/* 여기안 부터 조건에 따라 달라지게 Follow에 내려주는 프롭스값도 달라지고 랜더링도 달라짐 */}

--- a/src/pages/follow/yourFollow.jsx
+++ b/src/pages/follow/yourFollow.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
- import { Follow } from '../../components/follow/follow'
+import { Follow } from '../../components/follow/follow'
 import { FollowPageWrap, FollowPageUl } from './followstyle';
 import { FollowerHeader } from '../../components/header/header';
 
@@ -52,7 +52,7 @@ export const YourFollow = () => {
 
   return (
     <>
-      <FollowerHeader />
+      <FollowerHeader target={target}/>
       <FollowPageWrap>
         <FollowPageUl>
          {/* 여기안 부터 조건에 따라 달라지게 Follow에 내려주는 프롭스값도 달라지고 랜더링도 달라짐 */}


### PR DESCRIPTION
### 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 :  
- [ ] 스타일 : 
- [x] 리팩토링 :  모든 헤더에 뒤로가기 컴포넌트를 적용, 팔로워 헤더에 target props를 내려 팔로워, 팔로잉 클릭 시 헤더 텍스트가 각각 followers, followings로 바뀌도록 수정
- [ ] 버그 수정 : 
- [ ] 문서 수정 : 
- [ ] 기타 : 


### 🙏🏻 기대 결과
- 뒤로가기 컴포넌트 적용 후에도 뒤로가기 기능 잘 작동
- 팔로워 클릭 시 헤더에 followers 텍스트가, 팔로잉 클릭 시 헤더에 followings 텍스트가 뜸

### 📸 스크린샷


### 🙂 전달사항

### 😉 Issue Number
close : #156

